### PR TITLE
try fix install chromium with playwright bundled cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "Claude Quota Tracker" extension will be documented in this file.
 
-## [1.0.5] - 2026-02-18
+## [1.0.5] - 2026-02-19
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "Claude Quota Tracker" extension will be documented in this file.
 
+## [1.0.5] - 2026-02-18
+
+### Fixed
+
+- **Chromium Installation** (issues [#11](https://github.com/jonis100/claude-quota-tracker/issues/11), [#13](https://github.com/jonis100/claude-quota-tracker/issues/13)): Fixed Chromium installation failing with `playwright-core: not found`
+  - The extension now invokes `playwright-core`'s bundled CLI directly via `node "<extensionPath>/node_modules/playwright-core/cli.js" install chromium` instead of relying on `npx playwright`
+  - Falls back to `npx playwright install chromium` when extension path is not available
+
 ## [1.0.4] - 2026-02-09
 
 ### Fixed

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -60,7 +60,7 @@ This will create a `.vsix` file (e.g., `claude-quota-tracker-1.0.1.vsix`)
 ### Step 3: Test the Package Locally
 
 ```bash
-code --install-extension claude-quota-tracker-1.0.1.vsix
+code --install-extension claude-quota-tracker-1.0.5.vsix
 ```
 
 ### Step 4: Publish to Marketplace

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Access via Command Palette (Ctrl/Cmd + Shift + P):
 
 If you see this error, click on it and choose "Install Now" to automatically install Chromium. Alternatively, run `npx playwright install chromium` in your terminal.
 
+### Chromium fails to launch (containers / minimal servers)
+
+On minimal environments like LXC containers or headless servers, Chromium may download but fail to launch due to missing system libraries. Install the browser with its OS dependencies:
+
+```bash
+npx playwright install --with-deps chromium
+```
+
+This runs `apt-get install` for the required libraries (libnss3, libgbm1, libasound2, etc.). Requires root or sudo.
+
 ### "Session key and organization ID not configured"
 
 Make sure you've set both credentials in Settings → Claude Quota

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-quota-tracker",
   "displayName": "Claude Quota Tracker",
   "description": "Track your Claude.ai subscription usage with real-time quota monitoring in VS Code status bar",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "yonis",
   "icon": "assets/CQT-128c.png",
   "repository": {

--- a/src/utils/chromiumService.ts
+++ b/src/utils/chromiumService.ts
@@ -75,22 +75,25 @@ export async function installChromium(
     logger.info("ChromiumService", "Starting Chromium installation...");
 
     onProgress?.("Installing Chromium browser...");
-    const command = "npx playwright install chromium";
 
     const execOptions: Parameters<typeof execAsync>[1] = {
       maxBuffer: 10 * 1024 * 1024,
     };
 
+    let command: string;
     if (extensionPath) {
       execOptions.cwd = extensionPath;
+      const cliPath = `${extensionPath}/node_modules/playwright-core/cli.js`;
+      command = `node "${cliPath}" install chromium`;
       logger.debug(
         "ChromiumService",
         `Running installation from extension path: ${extensionPath}`,
       );
     } else {
+      command = "npx playwright install chromium";
       logger.warn(
         "ChromiumService",
-        "Extension path not set - installation may fail in code-server environments",
+        "Extension path not set - falling back to npx playwright install chromium",
       );
     }
 

--- a/src/utils/chromiumService.ts
+++ b/src/utils/chromiumService.ts
@@ -16,6 +16,7 @@ import { chromium } from "playwright-core";
 import { logger } from "./logger";
 import { exec } from "child_process";
 import { promisify } from "util";
+import * as path from "path";
 
 const execAsync = promisify(exec);
 
@@ -83,7 +84,7 @@ export async function installChromium(
     let command: string;
     if (extensionPath) {
       execOptions.cwd = extensionPath;
-      const cliPath = `${extensionPath}/node_modules/playwright-core/cli.js`;
+      const cliPath = path.join(extensionPath, "node_modules", "playwright-core", "cli.js");
       command = `node "${cliPath}" install chromium`;
       logger.debug(
         "ChromiumService",


### PR DESCRIPTION
### Try Fix Chromium Installation

- **Chromium Installation** (issues [#11](https://github.com/jonis100/claude-quota-tracker/issues/11), [#13](https://github.com/jonis100/claude-quota-tracker/issues/13)): Fixed Chromium installation failing with `playwright-core: not found`
  - The extension now invokes `playwright-core`'s bundled CLI directly via `node "<extensionPath>/node_modules/playwright-core/cli.js" install chromium` instead of relying on `npx playwright`
  - Falls back to `npx playwright install chromium` when extension path is not available